### PR TITLE
Feat: Issue #1214: Add support for seed rolling

### DIFF
--- a/data/hpse-contract-schema-1.0.34.json
+++ b/data/hpse-contract-schema-1.0.34.json
@@ -7436,6 +7436,26 @@
               }
             }
           }
+        },
+        {
+          "env": {
+            "volumes": {
+              "test": {
+                "seed": "new env phrase",
+                "previousSeed": "old env phrase"
+              }
+            }
+          },
+          "workload": {
+            "volumes": {
+              "test": {
+                "mount": "/mnt/data",
+                "filesystem": "ext4",
+                "seed": "new workload phrase",
+                "previousSeed": "old workload phrase"
+              }
+            }
+          }
         }
       ],
       "$defs": {
@@ -7468,12 +7488,33 @@
               "$ref": "#/allOf/3/$defs/workloadVolume"
             }
           },
-          "additionalProperties": false,
           "examples": [
             {
               "test": {
                 "mount": "/mnt/data",
                 "seed": "fancy phrase"
+              }
+            },
+            {
+              "test": {
+                "mount": "/mnt/data",
+                "filesystem": "ext4",
+                "seed": "fancy phrase"
+              }
+            },
+            {
+              "test": {
+                "mount": "/mnt/data",
+                "seed": "new fancy phrase",
+                "previousSeed": "old fancy phrase"
+              }
+            },
+            {
+              "test": {
+                "mount": "/mnt/data",
+                "seed": "new fancy phrase",
+                "previousSeed": "old fancy phrase",
+                "filesystem": "ext4"
               }
             }
           ]
@@ -7492,6 +7533,13 @@
             {
               "test": {
                 "seed": "fancy phrase"
+              }
+            },
+            {
+              "test": {
+                "mount": "/mnt/data",
+                "seed": "new fancy phrase",
+                "previousSeed": "old fancy phrase"
               }
             }
           ]
@@ -7514,6 +7562,9 @@
             "seed": {
               "$ref": "#/allOf/3/$defs/seed"
             },
+            "previousSeed": {
+              "$ref": "#/allOf/3/$defs/previousSeed"
+            },
             "kms": {
               "$ref": "#/allOf/3/$defs/kms"
             },
@@ -7534,6 +7585,9 @@
           "properties": {
             "seed": {
               "$ref": "#/allOf/3/$defs/seed"
+            },
+            "previousSeed": {
+              "$ref": "#/allOf/3/$defs/previousSeed"
             }
           },
           "required": [
@@ -7554,12 +7608,24 @@
             },
             "seed": {
               "$ref": "#/allOf/3/$defs/seed"
+            },
+            "previousSeed": {
+              "$ref": "#/allOf/3/$defs/previousSeed"
             }
           },
           "required": [
             "seed"
           ],
           "additionalProperties": false
+        },
+        "previousSeed": {
+          "type": "string",
+          "title": "previousSeed",
+          "description": "Part of the encryption seed rolling used to encrypt the device. Mention the old key",
+          "minLength": 3,
+          "examples": [
+            "Lorem Ipsum"
+          ]
         },
         "seed": {
           "type": "string",


### PR DESCRIPTION
Hello Team,
While performing seed rolling with the following Contract through Terraform, the `terraform apply` failed.

```json
{
  "env" : {
    "type" : "env",
    "logging" : {
      "logDNA" : {
        "ingestionKey" : var.logdna_ingestion_key,
        "hostname" : var.logdna_ingestion_hostname,
        "port": 6514
      }
    },  
    "volumes": {
      "datavolume": {
        "seed": "testtest111",
        "previousSeed": "testtest11"
      }
    }
  },
  "workload" : {
    "type" : "workload",
    "compose" : {
      "archive" : hpcr_tgz.contract.rendered
    },
    "volumes": {
      "datavolume": {
        "filesystem": "ext4",
        "mount": "/mnt/data",
        "seed": "testtest111",
        "previousSeed": "testtest11"
      }
    }
  }
}
```

The error was the following:-
```bash
Plan: 0 to add, 5 to change, 0 to destroy.
╷
│ Error: /workload/volumes/datavolume: {"filesystem":"ext4"... additional properties are not allowed
│ 
│   with hpcr_contract_encrypted.contract,
│   on terraform.tf line 144, in resource "hpcr_contract_encrypted" "contract":
│  144:   contract = local.contract
│ 
╵
╷
│ Error: /env/volumes/datavolume: {"previousSeed":"tes... did not match any of the specified OneOf schemas
│ 
│   with hpcr_contract_encrypted.contract,
│   on terraform.tf line 144, in resource "hpcr_contract_encrypted" "contract":
│  144:   contract = local.contract
│ 
╵
```

This PR resolves this issue.