### PR TITLE
fix: update NODE_VERSION to fix Semantic Release in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   # Currently no way to detect automatically
   DEFAULT_BRANCH: main
   GO_VERSION: 1.20.5 # renovate: datasource=golang-version depName=golang
-  NODE_VERSION: 18
+  NODE_VERSION: 20.11
   DRY_RUN: true
 
 jobs:


### PR DESCRIPTION
The following changes to GitHub actions YAML file :
1. Update NODE_VERSION to 20.11 to fix Semantic Release error.