### PR TITLE
Update the location of s390x-encrypt.crt

### DIFF
--- a/datasource/datasource_certificates.go
+++ b/datasource/datasource_certificates.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	// default template used to download certificates
-	defaultTemplate = "https://cloud.ibm.com/media/docs/downloads/hyper-protect-container-runtime/ibm-hyper-protect-container-runtime-{{.Major}}-{{.Minor}}-s390x-{{.Patch}}-encrypt.crt"
+	defaultTemplate = "https://hpvsvpcubuntu.s3.us.cloud-object-storage.appdomain.cloud/s390x-{{.Patch}}/ibm-hyper-protect-container-runtime-{{.Major}}-{{.Minor}}-s390x-{{.Patch}}-encrypt.crt"
 
 	// template key
 	KeyMajor = "Major"


### PR DESCRIPTION
Starting patch version: 22, IBM puts the HPCR contract in a different location

Reference update in the ticket:

Greetings,
we had to move/copy the certificates to different storage.

Starting from release 22 and going forward the certificates will be part of https://hpvsvpcubuntu.s3.us.cloud-object-storage.appdomain.cloud/s390x-RELEASEVERSION/ibm-hyper-protect-container-runtime-1-0-s390x-RELEASEVERSION-intermediate.crt

We have already copied the previous version certificate to the above mentioned storage. Document links will be updated at the earliest for older versions.

If there is any further change in location we will notify

Regards,
Alessandro R.
Security Support Engineer
IBM Cloud